### PR TITLE
use if/elseif instead of individual if blocks for each request code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 .DS_Store
 /build
 /captures
+.idea/
+
+Aftermath.iml
+aftermath/aftermath.iml
+sample/sample.iml
+aftermath-annotations/aftermath-annotations.iml
+aftermath-processor/aftermath-processor.iml
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@
 /captures
 .idea/
 
-Aftermath.iml
-aftermath/aftermath.iml
-sample/sample.iml
-aftermath-annotations/aftermath-annotations.iml
-aftermath-processor/aftermath-processor.iml
+*.iml
 
 

--- a/aftermath-processor/src/main/java/org/michaelevans/aftermath/BindingClass.java
+++ b/aftermath-processor/src/main/java/org/michaelevans/aftermath/BindingClass.java
@@ -66,11 +66,17 @@ final class BindingClass {
                 .addParameter(ClassName.get("android.content", "Intent"), "data", Modifier.FINAL);
 
         if (!activityResultBindings.isEmpty()) {
+            boolean first = true;
             for (OnActivityResultBinding binding : activityResultBindings.values()) {
-                builder.beginControlFlow("if (requestCode == $L)", binding.requestCode);
+                if (first) {
+                    builder.beginControlFlow("if (requestCode == $L)", binding.requestCode);
+                    first = false;
+                } else {
+                    builder.nextControlFlow("else if (requestCode == $L)", binding.requestCode);
+                }
                 builder.addStatement("target.$L(resultCode, data)", binding.name);
-                builder.endControlFlow();
             }
+            builder.endControlFlow();
         }
 
         return builder.build();


### PR DESCRIPTION
This is a small commit that attempts to clean up the formatting of the generated file by using `if/elseif` control flow blocks instead of multiple `if` statements.

Additionally, it seems that `.iml` files weren't being ignored, so I added those to the main gitignore

The source output now looks like this:

```java
public class MainActivity$$Aftermath<T extends org.michaelevans.aftermath.sample.MainActivity> implements IOnActivityForResult<T> {
  @Override
  public void onActivityResult(final T target, final int requestCode, final int resultCode, final Intent data) {
    if (requestCode == 1) {
      target.onContactPicked(resultCode, data);
    } else if (requestCode == 2) {
      target.onOtherRequest(resultCode, data);
    }
  }
}
```